### PR TITLE
Hide chat history in sidebar

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -233,54 +233,20 @@ const Chat: React.FC = () => {
                     </div>
                 </div>
 
-                {/* Chat List */}
+                {/* Chat List - Hidden */}
                 <div className="flex-1 overflow-y-auto">
-                    {chats.map((chat) => {
-                        const chatName = getChatName(chat);
-                        const chatAvatar = getChatAvatar(chat);
-
-                        return (
-                            <div
-                                key={chat._id}
-                                onClick={() => setCurrentChat(chat as any)}
-                                className={`p-4 border-b border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors ${currentChat?._id === chat._id ? 'bg-primary-50 border-primary-200' : ''
-                                    }`}
-                            >
-                                <div className="flex items-center gap-3">
-                                    <Avatar user={chatAvatar || user!} size="md" showStatus />
-                                    <div className="flex-1 min-w-0">
-                                        <div className="flex items-center justify-between">
-                                            <h3 className="font-medium text-gray-900 truncate">{chatName}</h3>
-                                            {chat.lastMessage && (
-                                                <span className="text-xs text-gray-500">
-                                                    {formatChatTime(chat.lastMessage.createdAt)}
-                                                </span>
-                                            )}
-                                        </div>
-                                        <div className="flex items-center justify-between">
-                                            <p className="text-sm text-gray-500 truncate">
-                                                {chat.lastMessage ? (
-                                                    <>
-                                                        <span className="font-medium">
-                                                            {chat.lastMessage.sender._id === user?._id ? 'You' : chat.lastMessage.sender.username}
-                                                        </span>
-                                                        : {chat.lastMessage.content}
-                                                    </>
-                                                ) : (
-                                                    'No messages yet'
-                                                )}
-                                            </p>
-                                            {chat.unreadCount > 0 && (
-                                                <span className="bg-primary-600 text-white text-xs rounded-full px-2 py-1 min-w-[20px] text-center">
-                                                    {chat.unreadCount}
-                                                </span>
-                                            )}
-                                        </div>
-                                    </div>
-                                </div>
+                    {/* Chat history is hidden - no chats displayed */}
+                    <div className="flex flex-col items-center justify-center h-full text-gray-500">
+                        <div className="text-center p-8">
+                            <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
+                                <Users className="w-8 h-8 text-gray-400" />
                             </div>
-                        );
-                    })}
+                            <h3 className="text-lg font-medium text-gray-900 mb-2">No Chat History</h3>
+                            <p className="text-sm text-gray-500 mb-4">
+                                Start a new conversation by clicking the buttons below
+                            </p>
+                        </div>
+                    </div>
                 </div>
 
                 {/* New Chat Buttons */}


### PR DESCRIPTION
Hide chat history from the sidebar and replace it with a placeholder to meet user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-14379396-0beb-40d4-9ef9-d437148426ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14379396-0beb-40d4-9ef9-d437148426ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

